### PR TITLE
Unify peer storage and persist to SD card

### DIFF
--- a/palnagotchi/palnagotchi.ino
+++ b/palnagotchi/palnagotchi.ino
@@ -13,6 +13,8 @@
 #endif
 
 #include "esp_system.h"
+#include "pwngrid.h"
+#include "pwnbeacon.h"
 #include "storage.h"
 #include "ui.h"
 
@@ -61,6 +63,7 @@ void setup() {
   initMood();
   initPwnbeacon();
   initPwngrid();
+  storageLoadPeers();
   initUi();
 }
 

--- a/palnagotchi/pwnbeacon.cpp
+++ b/palnagotchi/pwnbeacon.cpp
@@ -5,14 +5,6 @@
 #include <NimBLEDevice.h>
 #include <mbedtls/sha256.h>
 
-uint8_t pwnbeacon_friends_run = 0;
-pwnbeacon_peer pwnbeacon_peers[PWNBEACON_MAX_PEERS];
-String pwnbeacon_last_friend_name = "";
-
-uint8_t getPwnbeaconRunTotalPeers() { return pwnbeacon_friends_run; }
-String getPwnbeaconLastFriendName() { return pwnbeacon_last_friend_name; }
-pwnbeacon_peer *getPwnbeaconPeers() { return pwnbeacon_peers; }
-
 char pwnbeacon_name[PWNBEACON_ADV_MAX_NAME_LEN + 1] = {0};
 char pwnbeacon_identity[129] = {0};
 char pwnbeacon_face[64] = "(O__O)";
@@ -77,76 +69,38 @@ void buildAdvPayload(uint8_t *buf, size_t *len) {
   memcpy(buf, &adv, *len);
 }
 
-int findPeerByFingerprint(const uint8_t *fp) {
-  for (uint8_t i = 0; i < pwnbeacon_friends_run; i++) {
-    if (memcmp(pwnbeacon_peers[i].fingerprint, fp, PWNBEACON_FINGERPRINT_LEN) == 0) {
-      return i;
-    }
-  }
-  return -1;
-}
-
 void pwnbeaconAddPeer(const uint8_t *data, size_t len, int8_t rssi,
                       const char *ble_name) {
-  if (len < 10) {
-    return;
-  }
+  if (len < 10) return;
 
   pwnbeacon_adv adv;
   memset(&adv, 0, sizeof(adv));
   size_t copy_len = len < sizeof(adv) ? len : sizeof(adv);
   memcpy(&adv, data, copy_len);
 
-  if (adv.version != PWNBEACON_PROTOCOL_VERSION) {
-    return;
+  if (adv.version != PWNBEACON_PROTOCOL_VERSION) return;
+  if (memcmp(adv.fingerprint, pwnbeacon_fingerprint, PWNBEACON_FINGERPRINT_LEN) == 0) return;
+
+  // Build fingerprint hex string as identity
+  char fp_hex[PWNBEACON_FINGERPRINT_LEN * 2 + 1];
+  for (int i = 0; i < PWNBEACON_FINGERPRINT_LEN; i++) {
+    snprintf(fp_hex + i * 2, 3, "%02x", adv.fingerprint[i]);
   }
 
-  if (memcmp(adv.fingerprint, pwnbeacon_fingerprint, PWNBEACON_FINGERPRINT_LEN) == 0) {
-    return;
-  }
-
-  int idx = findPeerByFingerprint(adv.fingerprint);
-
-  if (idx >= 0) {
-    pwnbeacon_peers[idx].rssi = rssi;
-    pwnbeacon_peers[idx].last_seen = millis();
-    pwnbeacon_peers[idx].gone = false;
-    pwnbeacon_peers[idx].pwnd_run = adv.pwnd_run;
-    pwnbeacon_peers[idx].pwnd_tot = adv.pwnd_tot;
-    return;
-  }
-
-  if (pwnbeacon_friends_run >= PWNBEACON_MAX_PEERS) {
-    return;
-  }
-
+  // Resolve name
   uint8_t name_len = adv.name_len;
-  if (name_len > PWNBEACON_ADV_MAX_NAME_LEN) {
-    name_len = PWNBEACON_ADV_MAX_NAME_LEN;
-  }
+  if (name_len > PWNBEACON_ADV_MAX_NAME_LEN) name_len = PWNBEACON_ADV_MAX_NAME_LEN;
 
-  memset(&pwnbeacon_peers[pwnbeacon_friends_run], 0, sizeof(pwnbeacon_peer));
+  String name;
   if (name_len > 0) {
-    pwnbeacon_peers[pwnbeacon_friends_run].name = String(adv.name).substring(0, name_len);
+    name = String(adv.name).substring(0, name_len);
   } else if (ble_name && strlen(ble_name) > 0) {
-    pwnbeacon_peers[pwnbeacon_friends_run].name = String(ble_name);
+    name = String(ble_name);
   } else {
-    pwnbeacon_peers[pwnbeacon_friends_run].name = "BLE peer";
+    name = "BLE peer";
   }
-  pwnbeacon_peers[pwnbeacon_friends_run].pwnd_run = adv.pwnd_run;
-  pwnbeacon_peers[pwnbeacon_friends_run].pwnd_tot = adv.pwnd_tot;
-  pwnbeacon_peers[pwnbeacon_friends_run].rssi = rssi;
-  pwnbeacon_peers[pwnbeacon_friends_run].last_seen = millis();
-  pwnbeacon_peers[pwnbeacon_friends_run].gone = false;
-  pwnbeacon_peers[pwnbeacon_friends_run].full_data = false;
-  memcpy(pwnbeacon_peers[pwnbeacon_friends_run].fingerprint, adv.fingerprint,
-         PWNBEACON_FINGERPRINT_LEN);
 
-  pwnbeacon_last_friend_name = pwnbeacon_peers[pwnbeacon_friends_run].name;
-  pwnbeacon_friends_run++;
-
-  storageLogPeer(pwnbeacon_peers[pwnbeacon_friends_run - 1].name.c_str(),
-                 "", "", "BLE");
+  storageAddPeer(name.c_str(), "", fp_hex, "ble", rssi);
 }
 
 // --- NimBLE Callbacks ---
@@ -317,27 +271,6 @@ void pwnbeaconScan(uint16_t duration_ms) {
   }
 }
 
-void checkPwnbeaconGonePeers() {
-  for (uint8_t i = 0; i < pwnbeacon_friends_run; i++) {
-    uint32_t away_ms = millis() - pwnbeacon_peers[i].last_seen;
-    if (away_ms > PEER_AWAY_THRESHOLD_MS) {
-      pwnbeacon_peers[i].gone = true;
-    }
-  }
-}
-
-signed int getPwnbeaconClosestRssi() {
-  signed int closest = -1000;
-
-  for (uint8_t i = 0; i < pwnbeacon_friends_run; i++) {
-    if (pwnbeacon_peers[i].gone == false && pwnbeacon_peers[i].rssi > closest) {
-      closest = pwnbeacon_peers[i].rssi;
-    }
-  }
-
-  return closest;
-}
-
 static bool ble_phase_active = false;
 
 bool pwnbeaconTick(String face) {
@@ -347,8 +280,6 @@ bool pwnbeaconTick(String face) {
     pwnbeaconScan(3000);
     return false;
   }
-
-  checkPwnbeaconGonePeers();
 
   if (isPwnbeaconScanning()) {
     return false;

--- a/palnagotchi/pwnbeacon.h
+++ b/palnagotchi/pwnbeacon.h
@@ -14,7 +14,6 @@
 #define PWNBEACON_PROTOCOL_VERSION  0x01
 #define PWNBEACON_ADV_MAX_NAME_LEN  8
 #define PWNBEACON_FINGERPRINT_LEN   6
-#define PWNBEACON_MAX_PEERS         32
 
 // --- Advertisement flags ---
 #define PWNBEACON_FLAG_ADVERTISE    0x01
@@ -22,34 +21,17 @@
 
 // --- Advertisement packet (compact binary, max 21 bytes) ---
 typedef struct __attribute__((packed)) {
-  uint8_t  version;                                // Protocol version (0x01)
-  uint8_t  flags;                                  // Bitfield flags
-  uint16_t pwnd_run;                               // Pwned this session (LE)
-  uint16_t pwnd_tot;                               // Pwned total (LE)
-  uint8_t  fingerprint[PWNBEACON_FINGERPRINT_LEN]; // First 6 bytes of identity SHA-256
-  uint8_t  name_len;                               // Name length (max 8)
-  char     name[PWNBEACON_ADV_MAX_NAME_LEN];       // Name (UTF-8, truncated)
+  uint8_t  version;
+  uint8_t  flags;
+  uint16_t pwnd_run;
+  uint16_t pwnd_tot;
+  uint8_t  fingerprint[PWNBEACON_FINGERPRINT_LEN];
+  uint8_t  name_len;
+  char     name[PWNBEACON_ADV_MAX_NAME_LEN];
 } pwnbeacon_adv;
-
-// --- Peer data ---
-typedef struct {
-  String    name;
-  uint16_t  pwnd_run;
-  uint16_t  pwnd_tot;
-  int8_t    rssi;
-  uint32_t  last_seen;
-  bool      gone;
-  bool      full_data;
-  uint8_t   fingerprint[PWNBEACON_FINGERPRINT_LEN];
-} pwnbeacon_peer;
 
 void initPwnbeacon();
 esp_err_t pwnbeaconAdvertise(String face);
 void pwnbeaconScan(uint16_t duration_ms);
 bool isPwnbeaconScanning();
 bool pwnbeaconTick(String face);
-pwnbeacon_peer* getPwnbeaconPeers();
-uint8_t getPwnbeaconRunTotalPeers();
-String getPwnbeaconLastFriendName();
-signed int getPwnbeaconClosestRssi();
-void checkPwnbeaconGonePeers();

--- a/palnagotchi/pwngrid.cpp
+++ b/palnagotchi/pwngrid.cpp
@@ -2,14 +2,6 @@
 #include "config.h"
 #include "storage.h"
 
-uint8_t pwngrid_friends_run = 0;
-pwngrid_peer pwngrid_peers[PWNGRID_MAX_PEERS];
-String pwngrid_last_friend_name = "";
-
-uint8_t getPwngridRunTotalPeers() { return pwngrid_friends_run; }
-String getPwngridLastFriendName() { return pwngrid_last_friend_name; }
-pwngrid_peer *getPwngridPeers() { return pwngrid_peers; }
-
 // Had to remove Radiotap headers, since its automatically added
 // Also had to remove the last 4 bytes (frame check sequence)
 const uint8_t pwngrid_beacon_raw[] = {
@@ -94,65 +86,10 @@ esp_err_t pwngridAdvertise(uint8_t channel, char session_id[18], String face) {
 }
 
 void pwngridAddPeer(JsonDocument &json, signed int rssi) {
-  for (uint8_t i = 0; i < pwngrid_friends_run; i++) {
-    // Check if peer identity is already in peers array
-    if (pwngrid_peers[i].identity == json["identity"].as<String>() &&
-        pwngrid_peers[i].session_id == json["session_id"].as<String>()) {
-      pwngrid_peers[i].last_ping = millis();
-      pwngrid_peers[i].gone = false;
-      pwngrid_peers[i].rssi = rssi;
-      return;
-    }
-  }
-
-  if (pwngrid_friends_run >= PWNGRID_MAX_PEERS) {
-    return;
-  }
-
-  pwngrid_peers[pwngrid_friends_run].rssi = rssi;
-  pwngrid_peers[pwngrid_friends_run].last_ping = millis();
-  pwngrid_peers[pwngrid_friends_run].gone = false;
-  pwngrid_peers[pwngrid_friends_run].name = json["name"].as<String>();
-  pwngrid_peers[pwngrid_friends_run].face = json["face"].as<String>();
-  pwngrid_peers[pwngrid_friends_run].epoch = json["epoch"].as<int>();
-  pwngrid_peers[pwngrid_friends_run].grid_version =
-      json["grid_version"].as<String>();
-  pwngrid_peers[pwngrid_friends_run].identity = json["identity"].as<String>();
-  pwngrid_peers[pwngrid_friends_run].pwnd_run = json["pwnd_run"].as<int>();
-  pwngrid_peers[pwngrid_friends_run].pwnd_tot = json["pwnd_tot"].as<int>();
-  pwngrid_peers[pwngrid_friends_run].session_id =
-      json["session_id"].as<String>();
-  pwngrid_peers[pwngrid_friends_run].timestamp = json["timestamp"].as<int>();
-  pwngrid_peers[pwngrid_friends_run].uptime = json["uptime"].as<int>();
-  pwngrid_peers[pwngrid_friends_run].version = json["version"].as<String>();
-  pwngrid_last_friend_name = pwngrid_peers[pwngrid_friends_run].name;
-  pwngrid_friends_run++;
-
-  storageIncrementTotalPeers();
-  storageLogPeer(pwngrid_peers[pwngrid_friends_run - 1].name.c_str(),
-                 pwngrid_peers[pwngrid_friends_run - 1].face.c_str(),
-                 "", "WiFi");
-}
-
-void checkPwngridGoneFriends() {
-  for (uint8_t i = 0; i < pwngrid_friends_run; i++) {
-    uint32_t away_ms = millis() - pwngrid_peers[i].last_ping;
-    if (away_ms > PEER_AWAY_THRESHOLD_MS) {
-      pwngrid_peers[i].gone = true;
-    }
-  }
-}
-
-signed int getPwngridClosestRssi() {
-  signed int closest = -1000;
-
-  for (uint8_t i = 0; i < pwngrid_friends_run; i++) {
-    if (pwngrid_peers[i].gone == false && pwngrid_peers[i].rssi > closest) {
-      closest = pwngrid_peers[i].rssi;
-    }
-  }
-
-  return closest;
+  storageAddPeer(json["name"].as<String>().c_str(),
+                 json["face"].as<String>().c_str(),
+                 json["identity"].as<String>().c_str(),
+                 "wifi", rssi);
 }
 
 void getMAC(char *addr, uint8_t *data, uint16_t offset) {
@@ -253,7 +190,6 @@ bool pwngridTick(uint8_t &channel, char *session_id, String face) {
   // End phase after cycling through all channels (~22 seconds)
   if (millis() - wifi_phase_start > (uint32_t)DWELL_TIME_MS * MAX_CHANNEL) {
     stopPwngridSniffing();
-    checkPwngridGoneFriends();
     wifi_phase_start = 0;
     return true;
   }

--- a/palnagotchi/pwngrid.h
+++ b/palnagotchi/pwngrid.h
@@ -6,30 +6,6 @@
 #include "esp_wifi.h"
 #include "esp_wifi_types.h"
 
-#define PWNGRID_MAX_PEERS 32
-
-typedef struct {
-  int epoch;
-  String face;
-  String grid_version;
-  String identity;
-  String name;
-  int pwnd_run;
-  int pwnd_tot;
-  String session_id;
-  int timestamp;
-  int uptime;
-  String version;
-  signed int rssi;
-  uint32_t last_ping;
-  bool gone;
-} pwngrid_peer;
-
 void initPwngrid();
 esp_err_t pwngridAdvertise(uint8_t channel, char session_id[18], String face);
 bool pwngridTick(uint8_t &channel, char *session_id, String face);
-pwngrid_peer* getPwngridPeers();
-uint8_t getPwngridRunTotalPeers();
-String getPwngridLastFriendName();
-signed int getPwngridClosestRssi();
-void checkPwngridGoneFriends();

--- a/palnagotchi/storage.cpp
+++ b/palnagotchi/storage.cpp
@@ -2,9 +2,15 @@
 #include "EEPROM.h"
 #include <SD.h>
 #include <SPI.h>
+#include <ArduinoJson.h>
 
 static bool sd_available = false;
-static uint16_t total_peers = 0;
+static uint16_t total_peers_eeprom = 0;
+
+// Unified peer list
+static storage_peer peers[STORAGE_MAX_PEERS];
+static uint8_t peer_count = 0;
+static String last_friend_name = "";
 
 // Ring buffer for recent log entries
 static String log_ring[STORAGE_LOG_RING_SIZE];
@@ -40,20 +46,15 @@ static void writeToSd(const String& line) {
 }
 
 void initStorage() {
-  // EEPROM
   EEPROM.begin(256);
-  EEPROM.get(0, total_peers);
+  EEPROM.get(0, total_peers_eeprom);
 
-  // SD card auto-detection
   #if defined(ARDUINO_M5STACK_CARDPUTER)
-    // Cardputer + Cardputer Adv — built-in SD slot
     SPI.begin(40, 39, 14, 12);
     sd_available = SD.begin(12);
   #elif defined(ARDUINO_M5STACK_ATOM)
-    // Atomic TF Card Reader (ESP32-PICO)
     sd_available = SD.begin(33);
   #elif defined(ARDUINO_M5STACK_ATOMS3)
-    // Atomic TF Card Reader (ESP32-S3) — needs HW verification
     SPI.begin(17, 8, 21, 15);
     sd_available = SD.begin(15);
   #endif
@@ -69,15 +70,130 @@ bool isSdAvailable() {
   return sd_available;
 }
 
-uint16_t storageGetTotalPeers() {
-  return total_peers;
+// --- Unified peer access ---
+
+storage_peer* storageGetPeers() {
+  return peers;
 }
 
-void storageIncrementTotalPeers() {
-  total_peers++;
-  EEPROM.put(0, total_peers);
-  EEPROM.commit();
+uint8_t storageGetPeerCount() {
+  return peer_count;
 }
+
+uint16_t storageGetTotalPeers() {
+  if (sd_available) {
+    return peer_count;
+  }
+  return total_peers_eeprom;
+}
+
+String storageGetLastFriendName() {
+  return last_friend_name;
+}
+
+signed int storageGetClosestRssi() {
+  signed int closest = -1000;
+  for (uint8_t i = 0; i < peer_count; i++) {
+    if (!peers[i].gone && peers[i].rssi > closest) {
+      closest = peers[i].rssi;
+    }
+  }
+  return closest;
+}
+
+// --- Peer mutations ---
+
+static int findPeer(const char* identity, const char* type) {
+  for (uint8_t i = 0; i < peer_count; i++) {
+    if (peers[i].type == type && peers[i].identity == identity) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void storageAddPeer(const char* name, const char* face,
+                    const char* identity, const char* type,
+                    signed int rssi) {
+  int idx = findPeer(identity, type);
+  if (idx >= 0) {
+    peers[idx].rssi = rssi;
+    peers[idx].gone = false;
+    return;
+  }
+
+  if (peer_count >= STORAGE_MAX_PEERS) return;
+
+  peers[peer_count].name     = name;
+  peers[peer_count].face     = face ? face : "";
+  peers[peer_count].identity = identity;
+  peers[peer_count].type     = type;
+  peers[peer_count].rssi     = rssi;
+  peers[peer_count].gone     = false;
+  last_friend_name = name;
+  peer_count++;
+
+  storageLogPeer(name, face, "", type);
+  storageSavePeers();
+}
+
+// --- Persistence ---
+
+void storageSavePeers() {
+  if (!sd_available) {
+    total_peers_eeprom++;
+    EEPROM.put(0, total_peers_eeprom);
+    EEPROM.commit();
+    return;
+  }
+
+  JsonDocument doc;
+  JsonArray arr = doc.to<JsonArray>();
+
+  for (uint8_t i = 0; i < peer_count; i++) {
+    JsonObject obj = arr.add<JsonObject>();
+    obj["name"]     = peers[i].name;
+    obj["face"]     = peers[i].face;
+    obj["identity"] = peers[i].identity;
+    obj["type"]     = peers[i].type;
+    obj["rssi"]     = peers[i].rssi;
+  }
+
+  SD.remove("/palnagotchi/peers.json");
+  File f = SD.open("/palnagotchi/peers.json", FILE_WRITE);
+  if (f) {
+    serializeJson(doc, f);
+    f.close();
+  }
+}
+
+void storageLoadPeers() {
+  if (!sd_available) return;
+  if (!SD.exists("/palnagotchi/peers.json")) return;
+
+  File f = SD.open("/palnagotchi/peers.json", FILE_READ);
+  if (!f) return;
+
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, f);
+  f.close();
+  if (err) return;
+
+  JsonArray arr = doc.as<JsonArray>();
+  for (JsonObject obj : arr) {
+    if (peer_count >= STORAGE_MAX_PEERS) break;
+
+    peers[peer_count].name     = obj["name"] | "";
+    peers[peer_count].face     = obj["face"] | "";
+    peers[peer_count].identity = obj["identity"] | "";
+    peers[peer_count].type     = obj["type"] | "";
+    peers[peer_count].rssi     = obj["rssi"] | -100;
+    peers[peer_count].gone     = true;
+    peer_count++;
+  }
+}
+
+// --- Chat log ---
 
 void storageLogPeer(const char* name, const char* face,
                     const char* phrase, const char* source) {
@@ -107,7 +223,6 @@ uint8_t storageGetLogCount() {
 String storageGetLogEntry(uint8_t index) {
   if (index >= log_count) return "";
 
-  // Ring buffer: oldest entry is at (head - count), newest at (head - 1)
   uint8_t pos = (log_head - log_count + index + STORAGE_LOG_RING_SIZE) % STORAGE_LOG_RING_SIZE;
   return log_ring[pos];
 }

--- a/palnagotchi/storage.h
+++ b/palnagotchi/storage.h
@@ -3,13 +3,34 @@
 #include "Arduino.h"
 
 #define STORAGE_LOG_RING_SIZE 32
+#define STORAGE_MAX_PEERS     64
+
+typedef struct {
+  String     name;
+  String     face;
+  String     identity;
+  String     type;       // "wifi" or "ble"
+  signed int rssi;
+  bool       gone;
+} storage_peer;
 
 void     initStorage();
 bool     isSdAvailable();
 
-// Peer counter (EEPROM)
-uint16_t storageGetTotalPeers();
-void     storageIncrementTotalPeers();
+// Unified peer access
+storage_peer* storageGetPeers();
+uint8_t    storageGetPeerCount();
+uint16_t   storageGetTotalPeers();
+String     storageGetLastFriendName();
+signed int storageGetClosestRssi();
+
+// Peer mutations (called by pwngrid/pwnbeacon)
+void     storageAddPeer(const char* name, const char* face,
+                        const char* identity, const char* type,
+                        signed int rssi);
+// Persistence
+void     storageSavePeers();
+void     storageLoadPeers();
 
 // Chat log (SD card if available, always in ring buffer)
 void     storageLogPeer(const char* name, const char* face,

--- a/palnagotchi/ui.cpp
+++ b/palnagotchi/ui.cpp
@@ -140,30 +140,10 @@ void updateUi(bool show_toolbars, uint8_t channel) {
   String mood_face = getCurrentMoodFace();
   String mood_phrase = getCurrentMoodPhrase();
   bool mood_broken = isCurrentMoodBroken();
-  uint16_t total_peers = storageGetTotalPeers();
-
-  // Merge WiFi + BLE peer counts
-  uint8_t wifi_peers = getPwngridRunTotalPeers();
-  uint8_t ble_peers = getPwnbeaconRunTotalPeers();
-  uint8_t combined_run = wifi_peers + ble_peers;
-
-  // Pick last friend name and closest RSSI from whichever is more recent
-  String last_name = getPwngridLastFriendName();
-  signed int closest_rssi = getPwngridClosestRssi();
-  if (ble_peers > 0) {
-    if (last_name.length() == 0) {
-      last_name = getPwnbeaconLastFriendName();
-    }
-    int8_t ble_rssi = getPwnbeaconClosestRssi();
-    if (ble_rssi > closest_rssi) {
-      closest_rssi = ble_rssi;
-    }
-  }
-
   M5.Display.startWrite();
   drawTopCanvas(channel);
-  drawBottomCanvas(combined_run, total_peers + ble_peers,
-                   last_name, closest_rssi);
+  drawBottomCanvas(storageGetPeerCount(), storageGetTotalPeers(),
+                   storageGetLastFriendName(), storageGetClosestRssi());
 
   if (menu_open) {
     drawMenu();
@@ -333,13 +313,10 @@ void drawNearbyMenu() {
   canvas_main.setTextColor(GREEN);
   canvas_main.setTextDatum(top_left);
 
-  pwngrid_peer *wifi_peers = getPwngridPeers();
-  uint8_t wifi_len = getPwngridRunTotalPeers();
-  pwnbeacon_peer *ble_peers = getPwnbeaconPeers();
-  uint8_t ble_len = getPwnbeaconRunTotalPeers();
-  uint8_t total_len = wifi_len + ble_len;
+  storage_peer *all_peers = storageGetPeers();
+  uint8_t count = storageGetPeerCount();
 
-  if (total_len == 0) {
+  if (count == 0) {
     canvas_main.setTextColor(TFT_DARKGRAY);
     canvas_main.setCursor(0, PADDING);
     canvas_main.println("No nearby Pwnagotchis. Seriously?");
@@ -348,20 +325,12 @@ void drawNearbyMenu() {
   char display_str[50] = "";
   uint8_t row = 0;
 
-  // WiFi peers
-  for (uint8_t i = 0; i < wifi_len; i++) {
-    snprintf(display_str, sizeof(display_str), "%s %s [%s]", (menu_current_opt == row) ? ">" : " ",
-            wifi_peers[i].name.c_str(), getRssiBars(wifi_peers[i].rssi).c_str());
-    int y = PADDING + (row * ROW_SIZE / 2);
-    canvas_main.drawString(display_str, 0, y);
-    row++;
-  }
-
-  // BLE peers
-  for (uint8_t i = 0; i < ble_len; i++) {
-    if (ble_peers[i].gone) continue;
-    snprintf(display_str, sizeof(display_str), "%s %s BLE[%s]", (menu_current_opt == row) ? ">" : " ",
-            ble_peers[i].name.c_str(), getRssiBars(ble_peers[i].rssi).c_str());
+  for (uint8_t i = 0; i < count; i++) {
+    const char* type_tag = (all_peers[i].type == "ble") ? " BLE" : "";
+    snprintf(display_str, sizeof(display_str), "%s %s%s [%s]",
+            (menu_current_opt == row) ? ">" : " ",
+            all_peers[i].name.c_str(), type_tag,
+            getRssiBars(all_peers[i].rssi).c_str());
     int y = PADDING + (row * ROW_SIZE / 2);
     canvas_main.drawString(display_str, 0, y);
     row++;

--- a/palnagotchi/ui.h
+++ b/palnagotchi/ui.h
@@ -13,8 +13,6 @@
 #endif
 
 #include "mood.h"
-#include "pwngrid.h"
-#include "pwnbeacon.h"
 #include "storage.h"
 
 void initUi();


### PR DESCRIPTION
## Summary

- Replaces separate `pwngrid_peer` / `pwnbeacon_peer` arrays with a single unified `storage_peer` list in `storage.cpp`
- Both WiFi and BLE peers go through `storageAddPeer()` which handles dedup, chat logging, and persistence
- Peers are saved to `/palnagotchi/peers.json` on SD card after each new discovery; falls back to EEPROM counter when no SD is present
- On boot, `storageLoadPeers()` restores peers from SD (marked `gone` until re-discovered)
- UI nearby menu and status bar now read from the unified peer list — no more direct pwngrid/pwnbeacon access

## Test plan

- [ ] `pio run` builds clean
- [ ] Flash and verify peer discovery works for both WiFi and BLE
- [ ] With SD card: check `/palnagotchi/peers.json` is created after finding a peer
- [ ] Reboot: peers appear in nearby menu as gone, re-discovered peers become active
- [ ] Without SD card: verify EEPROM counter still increments