### PR TITLE
Add GATT client for full BLE peer identity

### DIFF
--- a/palnagotchi/pwnbeacon.cpp
+++ b/palnagotchi/pwnbeacon.cpp
@@ -300,6 +300,8 @@ bool pwnbeaconGattRead() {
     return false;
   }
 
+  bool got_data = false;
+
   NimBLERemoteService *svc = client->getService(
       NimBLEUUID(PWNBEACON_SERVICE_UUID));
   if (svc) {
@@ -314,6 +316,7 @@ bool pwnbeaconGattRead() {
           peers[target].identity = doc["identity"] | peers[target].identity;
           peers[target].name     = doc["name"] | peers[target].name;
           peers[target].face     = doc["face"] | peers[target].face;
+          got_data = true;
         }
       }
     }
@@ -325,6 +328,7 @@ bool pwnbeaconGattRead() {
       std::string val = face_char->readValue();
       if (val.length() > 0) {
         peers[target].face = val.c_str();
+        got_data = true;
       }
     }
 
@@ -335,6 +339,7 @@ bool pwnbeaconGattRead() {
       std::string val = name_char->readValue();
       if (val.length() > 0) {
         peers[target].name = val.c_str();
+        got_data = true;
       }
     }
   }
@@ -343,11 +348,13 @@ bool pwnbeaconGattRead() {
   NimBLEDevice::deleteClient(client);
 
   peers[target].full_data = true;
-  storageLogPeer(peers[target].name.c_str(),
-                 peers[target].face.c_str(), "", "BLE GATT");
-  storageSavePeers();
+  if (got_data) {
+    storageLogPeer(peers[target].name.c_str(),
+                   peers[target].face.c_str(), "", "BLE GATT");
+    storageSavePeers();
+  }
 
-  return true;
+  return got_data;
 }
 
 // --- Tick ---

--- a/palnagotchi/pwnbeacon.cpp
+++ b/palnagotchi/pwnbeacon.cpp
@@ -70,7 +70,7 @@ void buildAdvPayload(uint8_t *buf, size_t *len) {
 }
 
 void pwnbeaconAddPeer(const uint8_t *data, size_t len, int8_t rssi,
-                      const char *ble_name) {
+                      const char *ble_name, const char *addr) {
   if (len < 10) return;
 
   pwnbeacon_adv adv;
@@ -100,7 +100,7 @@ void pwnbeaconAddPeer(const uint8_t *data, size_t len, int8_t rssi,
     name = "BLE peer";
   }
 
-  storageAddPeer(name.c_str(), "", fp_hex, "ble", rssi);
+  storageAddPeer(name.c_str(), "", fp_hex, "ble", rssi, addr);
 }
 
 // --- NimBLE Callbacks ---
@@ -112,8 +112,9 @@ class PwnBeaconScanCallbacks : public NimBLEScanCallbacks {
       if (device->getServiceDataUUID(i).equals(NimBLEUUID(PWNBEACON_SERVICE_UUID))) {
         std::string svcData = device->getServiceData(i);
         std::string devName = device->getName();
+        std::string addr = device->getAddress().toString();
         pwnbeaconAddPeer((const uint8_t *)svcData.data(), svcData.length(),
-                         device->getRSSI(), devName.c_str());
+                         device->getRSSI(), devName.c_str(), addr.c_str());
         break;
       }
     }
@@ -271,11 +272,93 @@ void pwnbeaconScan(uint16_t duration_ms) {
   }
 }
 
+// --- GATT Client ---
+
+bool pwnbeaconGattRead() {
+  storage_peer *peers = storageGetPeers();
+  uint8_t count = storageGetPeerCount();
+
+  // Find first BLE peer needing GATT data
+  int target = -1;
+  for (uint8_t i = 0; i < count; i++) {
+    if (peers[i].type == "ble" && !peers[i].full_data &&
+        !peers[i].gone && peers[i].ble_addr.length() > 0) {
+      target = i;
+      break;
+    }
+  }
+
+  if (target < 0) return false;
+
+  NimBLEClient *client = NimBLEDevice::createClient();
+  client->setConnectTimeout(2);
+
+  NimBLEAddress addr(std::string(peers[target].ble_addr.c_str()), 0);
+  if (!client->connect(addr)) {
+    NimBLEDevice::deleteClient(client);
+    peers[target].full_data = true;
+    return false;
+  }
+
+  NimBLERemoteService *svc = client->getService(
+      NimBLEUUID(PWNBEACON_SERVICE_UUID));
+  if (svc) {
+    // Read full identity JSON
+    NimBLERemoteCharacteristic *id_char = svc->getCharacteristic(
+        NimBLEUUID(PWNBEACON_IDENTITY_CHAR_UUID));
+    if (id_char) {
+      std::string val = id_char->readValue();
+      if (val.length() > 0) {
+        JsonDocument doc;
+        if (deserializeJson(doc, val.c_str()) == DeserializationError::Ok) {
+          peers[target].identity = doc["identity"] | peers[target].identity;
+          peers[target].name     = doc["name"] | peers[target].name;
+          peers[target].face     = doc["face"] | peers[target].face;
+        }
+      }
+    }
+
+    // Read face (may be more current than identity JSON)
+    NimBLERemoteCharacteristic *face_char = svc->getCharacteristic(
+        NimBLEUUID(PWNBEACON_FACE_CHAR_UUID));
+    if (face_char) {
+      std::string val = face_char->readValue();
+      if (val.length() > 0) {
+        peers[target].face = val.c_str();
+      }
+    }
+
+    // Read full name
+    NimBLERemoteCharacteristic *name_char = svc->getCharacteristic(
+        NimBLEUUID(PWNBEACON_NAME_CHAR_UUID));
+    if (name_char) {
+      std::string val = name_char->readValue();
+      if (val.length() > 0) {
+        peers[target].name = val.c_str();
+      }
+    }
+  }
+
+  client->disconnect();
+  NimBLEDevice::deleteClient(client);
+
+  peers[target].full_data = true;
+  storageLogPeer(peers[target].name.c_str(),
+                 peers[target].face.c_str(), "", "BLE GATT");
+  storageSavePeers();
+
+  return true;
+}
+
+// --- Tick ---
+
 static bool ble_phase_active = false;
+static bool ble_gatt_done = false;
 
 bool pwnbeaconTick(String face) {
   if (!ble_phase_active) {
     ble_phase_active = true;
+    ble_gatt_done = false;
     pwnbeaconAdvertise(face);
     pwnbeaconScan(3000);
     return false;
@@ -285,7 +368,13 @@ bool pwnbeaconTick(String face) {
     return false;
   }
 
-  // Scan done — stop advertising so WiFi can use the radio
+  // After scan, attempt one GATT read before ending phase
+  if (!ble_gatt_done) {
+    ble_gatt_done = true;
+    pwnbeaconGattRead();
+  }
+
+  // Done — stop advertising so WiFi can use the radio
   ble_advertising->stop();
   ble_phase_active = false;
   return true;

--- a/palnagotchi/storage.cpp
+++ b/palnagotchi/storage.cpp
@@ -103,6 +103,13 @@ signed int storageGetClosestRssi() {
 
 // --- Peer mutations ---
 
+static void incrementEepromCounter() {
+  if (sd_available) return;
+  total_peers_eeprom++;
+  EEPROM.put(0, total_peers_eeprom);
+  EEPROM.commit();
+}
+
 static int findPeer(const char* identity, const char* type) {
   for (uint8_t i = 0; i < peer_count; i++) {
     if (peers[i].type == type && peers[i].identity == identity) {
@@ -138,6 +145,7 @@ void storageAddPeer(const char* name, const char* face,
   last_friend_name = name;
   peer_count++;
 
+  incrementEepromCounter();
   storageLogPeer(name, face, "", type);
   storageSavePeers();
 }
@@ -145,12 +153,7 @@ void storageAddPeer(const char* name, const char* face,
 // --- Persistence ---
 
 void storageSavePeers() {
-  if (!sd_available) {
-    total_peers_eeprom++;
-    EEPROM.put(0, total_peers_eeprom);
-    EEPROM.commit();
-    return;
-  }
+  if (!sd_available) return;
 
   JsonDocument doc;
   JsonArray arr = doc.to<JsonArray>();
@@ -164,6 +167,9 @@ void storageSavePeers() {
     obj["rssi"]     = peers[i].rssi;
     if (peers[i].ble_addr.length() > 0) {
       obj["ble_addr"] = peers[i].ble_addr;
+    }
+    if (peers[i].full_data) {
+      obj["full_data"] = true;
     }
   }
 
@@ -198,7 +204,7 @@ void storageLoadPeers() {
     peers[peer_count].ble_addr  = obj["ble_addr"] | "";
     peers[peer_count].rssi      = obj["rssi"] | -100;
     peers[peer_count].gone      = true;
-    peers[peer_count].full_data = false;
+    peers[peer_count].full_data = obj["full_data"] | false;
     peer_count++;
   }
 }

--- a/palnagotchi/storage.cpp
+++ b/palnagotchi/storage.cpp
@@ -114,22 +114,27 @@ static int findPeer(const char* identity, const char* type) {
 
 void storageAddPeer(const char* name, const char* face,
                     const char* identity, const char* type,
-                    signed int rssi) {
+                    signed int rssi, const char* ble_addr) {
   int idx = findPeer(identity, type);
   if (idx >= 0) {
     peers[idx].rssi = rssi;
     peers[idx].gone = false;
+    if (ble_addr && strlen(ble_addr) > 0) {
+      peers[idx].ble_addr = ble_addr;
+    }
     return;
   }
 
   if (peer_count >= STORAGE_MAX_PEERS) return;
 
-  peers[peer_count].name     = name;
-  peers[peer_count].face     = face ? face : "";
-  peers[peer_count].identity = identity;
-  peers[peer_count].type     = type;
-  peers[peer_count].rssi     = rssi;
-  peers[peer_count].gone     = false;
+  peers[peer_count].name      = name;
+  peers[peer_count].face      = face ? face : "";
+  peers[peer_count].identity  = identity;
+  peers[peer_count].type      = type;
+  peers[peer_count].rssi      = rssi;
+  peers[peer_count].gone      = false;
+  peers[peer_count].full_data = false;
+  peers[peer_count].ble_addr  = ble_addr ? ble_addr : "";
   last_friend_name = name;
   peer_count++;
 
@@ -157,6 +162,9 @@ void storageSavePeers() {
     obj["identity"] = peers[i].identity;
     obj["type"]     = peers[i].type;
     obj["rssi"]     = peers[i].rssi;
+    if (peers[i].ble_addr.length() > 0) {
+      obj["ble_addr"] = peers[i].ble_addr;
+    }
   }
 
   SD.remove("/palnagotchi/peers.json");
@@ -183,12 +191,14 @@ void storageLoadPeers() {
   for (JsonObject obj : arr) {
     if (peer_count >= STORAGE_MAX_PEERS) break;
 
-    peers[peer_count].name     = obj["name"] | "";
-    peers[peer_count].face     = obj["face"] | "";
-    peers[peer_count].identity = obj["identity"] | "";
-    peers[peer_count].type     = obj["type"] | "";
-    peers[peer_count].rssi     = obj["rssi"] | -100;
-    peers[peer_count].gone     = true;
+    peers[peer_count].name      = obj["name"] | "";
+    peers[peer_count].face      = obj["face"] | "";
+    peers[peer_count].identity  = obj["identity"] | "";
+    peers[peer_count].type      = obj["type"] | "";
+    peers[peer_count].ble_addr  = obj["ble_addr"] | "";
+    peers[peer_count].rssi      = obj["rssi"] | -100;
+    peers[peer_count].gone      = true;
+    peers[peer_count].full_data = false;
     peer_count++;
   }
 }

--- a/palnagotchi/storage.h
+++ b/palnagotchi/storage.h
@@ -10,8 +10,10 @@ typedef struct {
   String     face;
   String     identity;
   String     type;       // "wifi" or "ble"
+  String     ble_addr;   // BLE address for GATT connections
   signed int rssi;
   bool       gone;
+  bool       full_data;  // true after GATT read for BLE peers
 } storage_peer;
 
 void     initStorage();
@@ -27,7 +29,7 @@ signed int storageGetClosestRssi();
 // Peer mutations (called by pwngrid/pwnbeacon)
 void     storageAddPeer(const char* name, const char* face,
                         const char* identity, const char* type,
-                        signed int rssi);
+                        signed int rssi, const char* ble_addr = "");
 // Persistence
 void     storageSavePeers();
 void     storageLoadPeers();


### PR DESCRIPTION
## Summary

- After BLE scan completes, connects via GATT to one peer per phase to read full identity, face, and name
- Extends `storage_peer` with `ble_addr` (stored during scan) and `full_data` flag
- Reads Identity JSON, Face, and Name characteristics from the PwnBeacon GATT server
- 2-second connection timeout; peers that fail are marked `full_data = true` to avoid infinite retries
- Re-discovered peers (re-added via scan) keep their `full_data` status

Depends on #4 (unified peer storage).

## Test plan

- [ ] `pio run` builds clean
- [ ] Flash two devices running PwnBeacon
- [ ] Verify scan discovers peer with truncated name
- [ ] After next BLE phase, verify full name/face populated via GATT read
- [ ] Check peers.json includes `ble_addr` field
- [ ] Verify GATT read doesn't block longer than ~2 seconds on timeout