### PR TITLE
Add web AP mode with status page

### DIFF
--- a/palnagotchi/palnagotchi.ino
+++ b/palnagotchi/palnagotchi.ino
@@ -17,6 +17,7 @@
 #include "pwnbeacon.h"
 #include "storage.h"
 #include "ui.h"
+#include "webui.h"
 
 #define STATE_INIT 0
 #define STATE_WAKE 1
@@ -64,6 +65,7 @@ void setup() {
   initPwnbeacon();
   initPwngrid();
   storageLoadPeers();
+  initWebUi();
   initUi();
 }
 
@@ -97,6 +99,8 @@ void loop() {
   #ifdef ARDUINO_M5STACK_CARDPUTER
     M5Cardputer.update();
   #endif
+
+  webUiTick();
 
   if (state == STATE_HALT) return;
 

--- a/palnagotchi/pwngrid.cpp
+++ b/palnagotchi/pwngrid.cpp
@@ -133,6 +133,17 @@ void pwnSnifferCallback(void *buf, wifi_promiscuous_pkt_type_t type) {
   }
 }
 
+static void setApSsid(const char* ssid) {
+  wifi_config_t ap_config;
+  memset(&ap_config, 0, sizeof(ap_config));
+  strncpy((char*)ap_config.ap.ssid, ssid, sizeof(ap_config.ap.ssid) - 1);
+  ap_config.ap.ssid_len = strlen(ssid);
+  ap_config.ap.channel = 1;
+  ap_config.ap.authmode = WIFI_AUTH_OPEN;
+  ap_config.ap.max_connection = 2;
+  esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+}
+
 void initPwngrid() {
   esp_log_level_set("wifi", ESP_LOG_NONE);
 
@@ -140,6 +151,7 @@ void initPwngrid() {
   esp_wifi_init(&WIFI_INIT_CONFIG);
   esp_wifi_set_storage(WIFI_STORAGE_RAM);
   esp_wifi_set_mode(WIFI_MODE_AP);
+  setApSsid(PALNAGOTCHI_NAME);
 }
 
 static bool wifi_started = false;

--- a/palnagotchi/webui.cpp
+++ b/palnagotchi/webui.cpp
@@ -1,0 +1,132 @@
+#include "webui.h"
+#include "storage.h"
+#include "mood.h"
+#include "config.h"
+#include <WiFi.h>
+
+static WiFiServer server(80);
+
+void initWebUi() {
+  IPAddress ip(192, 168, 4, 1);
+  IPAddress gateway(192, 168, 4, 1);
+  IPAddress subnet(255, 255, 255, 0);
+  WiFi.softAPConfig(ip, gateway, subnet);
+  server.begin();
+}
+
+static String htmlEscape(const String& s) {
+  String out = s;
+  out.replace("&", "&amp;");
+  out.replace("<", "&lt;");
+  out.replace(">", "&gt;");
+  out.replace("\"", "&quot;");
+  return out;
+}
+
+static String rssiBar(signed int rssi) {
+  if (rssi >= -67) return "||||";
+  if (rssi >= -70) return "|||";
+  if (rssi >= -80) return "||";
+  if (rssi > -1000) return "|";
+  return "";
+}
+
+void webUiTick() {
+  WiFiClient client = server.accept();
+  if (!client) return;
+
+  // Wait for request data (up to 50ms)
+  uint32_t start = millis();
+  while (client.connected() && !client.available()) {
+    if (millis() - start > 50) break;
+  }
+
+  // Read and discard the request
+  while (client.available()) client.read();
+
+  // Send response
+  client.print(F("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n"));
+  client.print(F("<!DOCTYPE html><html><head><meta charset='utf-8'>"));
+  client.print(F("<meta http-equiv='refresh' content='5'>"));
+  client.print(F("<meta name='viewport' content='width=device-width,initial-scale=1'>"));
+  client.print(F("<title>Palnagotchi</title>"));
+  client.print(F("<style>"));
+  client.print(F("body{background:#000;color:#0f0;font-family:monospace;margin:20px;text-align:center}"));
+  client.print(F(".face{font-size:3em;margin:20px 0}"));
+  client.print(F(".phrase{font-size:1.2em;color:#0a0;margin-bottom:20px}"));
+  client.print(F("table{margin:20px auto;border-collapse:collapse;text-align:left}"));
+  client.print(F("th,td{padding:4px 12px;border-bottom:1px solid #030}"));
+  client.print(F("th{color:#0f0}td{color:#0a0}"));
+  client.print(F(".gone{color:#050}"));
+  client.print(F(".log{text-align:left;max-width:600px;margin:20px auto;font-size:0.9em;color:#0a0}"));
+  client.print(F("h2{color:#0f0;font-size:1em;margin-top:30px}"));
+  client.print(F("</style></head><body>"));
+
+  // Name
+  client.print(F("<div style='color:#0a0'>"));
+  client.print(PALNAGOTCHI_NAME);
+  client.print(F("</div>"));
+
+  // Face
+  client.print(F("<div class='face'>"));
+  client.print(htmlEscape(getCurrentMoodFace()));
+  client.print(F("</div>"));
+
+  // Phrase
+  client.print(F("<div class='phrase'>"));
+  client.print(htmlEscape(getCurrentMoodPhrase()));
+  client.print(F("</div>"));
+
+  // Peers
+  uint8_t peer_count = storageGetPeerCount();
+  client.print(F("<h2>Nearby ("));
+  client.print(peer_count);
+  client.print(F(" / "));
+  client.print(storageGetTotalPeers());
+  client.print(F(")</h2>"));
+
+  if (peer_count > 0) {
+    client.print(F("<table><tr><th>Name</th><th>Type</th><th>RSSI</th><th>Face</th></tr>"));
+    storage_peer *peers = storageGetPeers();
+    for (uint8_t i = 0; i < peer_count; i++) {
+      client.print(peers[i].gone ? F("<tr class='gone'>") : F("<tr>"));
+      client.print(F("<td>"));
+      client.print(htmlEscape(peers[i].name));
+      client.print(F("</td><td>"));
+      client.print(peers[i].type);
+      client.print(F("</td><td>"));
+      client.print(rssiBar(peers[i].rssi));
+      client.print(F(" ("));
+      client.print(peers[i].rssi);
+      client.print(F(")</td><td>"));
+      client.print(htmlEscape(peers[i].face));
+      client.print(F("</td></tr>"));
+    }
+    client.print(F("</table>"));
+  }
+
+  // Chat log
+  uint8_t log_count = storageGetLogCount();
+  client.print(F("<h2>Log</h2><div class='log'>"));
+  if (log_count == 0) {
+    client.print(F("<div style='color:#050'>No log entries yet.</div>"));
+  }
+  for (uint8_t i = 0; i < log_count; i++) {
+    client.print(F("<div>"));
+    client.print(htmlEscape(storageGetLogEntry(i)));
+    client.print(F("</div>"));
+  }
+  client.print(F("</div>"));
+
+  // Uptime
+  unsigned long secs = millis() / 1000;
+  char uptime[16];
+  snprintf(uptime, sizeof(uptime), "%02lu:%02lu:%02lu", secs / 3600, (secs % 3600) / 60, secs % 60);
+  client.print(F("<div style='margin-top:20px;color:#050'>UP "));
+  client.print(uptime);
+  if (isSdAvailable()) client.print(F(" | SD"));
+  client.print(F("</div>"));
+
+  client.print(F("</body></html>"));
+  client.stop();
+}

--- a/palnagotchi/webui.h
+++ b/palnagotchi/webui.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "Arduino.h"
+
+void initWebUi();
+void webUiTick();


### PR DESCRIPTION
## Summary

- Serves a status page at `192.168.4.1` via the existing WiFi AP
- AP SSID set to device name, open auth, no password
- Green-on-black terminal-style page showing:
  - Current face and phrase
  - Peer table (name, type, RSSI, face) with gone peers dimmed
  - Chat log from ring buffer
  - Uptime and SD status
- Auto-refreshes every 5 seconds
- Non-blocking: `webUiTick()` polls for clients each loop iteration
- No new library dependencies

Depends on #4 (unified peer storage).

## Test plan

- [ ] `pio run` builds clean
- [ ] Flash device, connect phone/laptop to AP SSID
- [ ] Navigate to `192.168.4.1` — page loads with face, peers, log
- [ ] Page auto-refreshes every 5 seconds
- [ ] Verify peer discovery and web UI work simultaneously
- [ ] Verify BLE phase doesn't break web connections (may be slow but functional)