### PR TITLE
Fix duplicate peer detection

### DIFF
--- a/palnagotchi/config.h
+++ b/palnagotchi/config.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #define PALNAGOTCHI_NAME     "Palnagotchi"
-#define PALNAGOTCHI_IDENTITY "32e9f315e92d974342c93d0fd952a914bfb4e6838953536ea6f63d54db6b9610"
+
+// Derived at boot from BLE MAC, shared across modules
+extern char palnagotchi_identity[65];
 
 #define PEER_AWAY_THRESHOLD_MS 120000

--- a/palnagotchi/pwnbeacon.cpp
+++ b/palnagotchi/pwnbeacon.cpp
@@ -7,7 +7,7 @@
 #include <mbedtls/sha256.h>
 
 char pwnbeacon_name[PWNBEACON_ADV_MAX_NAME_LEN + 1] = {0};
-char pwnbeacon_identity[129] = {0};
+char palnagotchi_identity[65] = {0};
 char pwnbeacon_face[64] = "(O__O)";
 uint16_t pwnbeacon_pwnd_run = 0;
 uint16_t pwnbeacon_pwnd_tot = 0;
@@ -36,7 +36,7 @@ String buildIdentityJson() {
   doc["face"]         = pwnbeacon_face;
   doc["epoch"]        = 1;
   doc["grid_version"] = "2.0.0-ble";
-  doc["identity"]     = pwnbeacon_identity;
+  doc["identity"]     = palnagotchi_identity;
   doc["pwnd_run"]     = pwnbeacon_pwnd_run;
   doc["pwnd_tot"]     = pwnbeacon_pwnd_tot;
   doc["session_id"]   = NimBLEDevice::getAddress().toString().c_str();
@@ -182,11 +182,17 @@ void initPwnbeacon() {
     }
   }
   pwnbeacon_name[PWNBEACON_ADV_MAX_NAME_LEN] = '\0';
-  strncpy(pwnbeacon_identity, PALNAGOTCHI_IDENTITY,
-          sizeof(pwnbeacon_identity) - 1);
-  computeFingerprint(pwnbeacon_identity, pwnbeacon_fingerprint);
 
   NimBLEDevice::init(PALNAGOTCHI_NAME);
+
+  // Derive unique identity from BLE MAC address via SHA-256 (must be after init)
+  std::string mac = NimBLEDevice::getAddress().toString();
+  uint8_t hash[32];
+  mbedtls_sha256((const unsigned char *)mac.c_str(), mac.length(), hash, 0);
+  for (int i = 0; i < 32; i++) {
+    snprintf(palnagotchi_identity + i * 2, 3, "%02x", hash[i]);
+  }
+  computeFingerprint(palnagotchi_identity, pwnbeacon_fingerprint);
 
   // GATT server
   ble_server = NimBLEDevice::createServer();
@@ -356,7 +362,8 @@ bool pwnbeaconGattRead() {
       if (val.length() > 0) {
         JsonDocument doc;
         if (deserializeJson(doc, val.c_str()) == DeserializationError::Ok) {
-          peers[target].identity = doc["identity"] | peers[target].identity;
+          // Do NOT overwrite identity — it holds the fingerprint hex
+          // used for deduplication in findPeer()
           const char* json_name = doc["name"] | "";
           if (strlen(json_name) > 0) {
             peers[target].name = json_name;

--- a/palnagotchi/pwngrid.cpp
+++ b/palnagotchi/pwngrid.cpp
@@ -37,7 +37,7 @@ esp_err_t pwngridAdvertise(uint8_t channel, char session_id[18], String face) {
   pal_json["face"] = face;
   pal_json["epoch"] = 1;
   pal_json["grid_version"] = "1.10.3";
-  pal_json["identity"] = PALNAGOTCHI_IDENTITY;
+  pal_json["identity"] = palnagotchi_identity;
   pal_json["pwnd_run"] = 0;
   pal_json["pwnd_tot"] = 0;
   pal_json["session_id"] = session_id;


### PR DESCRIPTION
## Summary
- **Fix dedup bug**: GATT read was overwriting the peer's fingerprint-based identity with the full identity string from JSON, causing `findPeer()` to miss matches on subsequent scans — resulting in the same peer being added over and over.
- **Fix shared identity**: `PALNAGOTCHI_IDENTITY` was hardcoded to the same value for all devices. Now each device derives a unique identity by SHA-256 hashing its BLE MAC address at boot.
- **Cleanup**: Removed the redundant `pwnbeacon_identity` buffer — everything uses the single shared `palnagotchi_identity` global from `config.h`.

## Test plan
- [ ] Flash two devices and verify they discover each other as distinct peers
- [ ] Verify the same peer is not added multiple times across scan cycles
- [ ] Verify GATT read still populates name and face without breaking dedup
- [ ] Verify WiFi pwngrid peers still show correct (unique) identity