### PR TITLE
Fix PwnBeacon payload truncation (10 → 13 bytes)

### DIFF
--- a/palnagotchi/pwnbeacon.cpp
+++ b/palnagotchi/pwnbeacon.cpp
@@ -258,9 +258,9 @@ esp_err_t pwnbeaconAdvertise(String face) {
   buildAdvPayload(adv_payload, &adv_payload_len);
 
   // BLE scan response: 31 bytes max, 128-bit UUID takes 18 bytes overhead,
-  // leaving ~13 for data. Clamp to 10 for safety.
-  if (adv_payload_len > 10) {
-    adv_payload_len = 10;
+  // leaving 13 for data.
+  if (adv_payload_len > 13) {
+    adv_payload_len = 13;
   }
 
   NimBLEAdvertisementData advData;


### PR DESCRIPTION
## Summary
- Fix advertisement payload truncation from 10 to 13 bytes
- The scan response allows exactly 13 bytes after 128-bit UUID overhead (31 - 18 = 13)
- Truncating to 10 cut into the fingerprint field, making the payload unparseable by peers (PwnBook validates minimum 10 bytes but needs all 13 for a complete header)

## Test plan
- [ ] Verify palnagotchi advertisements are detected by PwnBook and GhostBLE
- [ ] Verify fingerprint is fully transmitted (6 bytes intact)